### PR TITLE
[WINMINE] Mine placing bug fix & add Shift+Click hotkey

### DIFF
--- a/reactos/base/applications/games/winmine/main.c
+++ b/reactos/base/applications/games/winmine/main.c
@@ -883,7 +883,7 @@ static LRESULT WINAPI MainProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPara
 
     case WM_LBUTTONDOWN:
         WINE_TRACE("WM_LBUTTONDOWN\n");
-        if( wParam & MK_RBUTTON )
+        if( wParam & ( MK_RBUTTON | MK_SHIFT ) )
             msg = WM_MBUTTONDOWN;
         TestBoard( hWnd, &board, (short)LOWORD(lParam), (short)HIWORD(lParam), msg );
         SetCapture( hWnd );
@@ -891,7 +891,7 @@ static LRESULT WINAPI MainProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPara
 
     case WM_LBUTTONUP:
         WINE_TRACE("WM_LBUTTONUP\n");
-        if( wParam & MK_RBUTTON )
+        if( wParam & ( MK_RBUTTON | MK_SHIFT ) )
             msg = WM_MBUTTONUP;
         TestBoard( hWnd, &board, (short)LOWORD(lParam), (short)HIWORD(lParam), msg );
         ReleaseCapture();

--- a/reactos/base/applications/games/winmine/main.c
+++ b/reactos/base/applications/games/winmine/main.c
@@ -342,8 +342,8 @@ static void PlaceMines ( BOARD *p_board, int selected_col, int selected_row )
     /* create mines */
     i = 0;
     while( (unsigned) i < p_board->mines ) {
-        col = (int) (p_board->cols * (float) rand() / RAND_MAX + 1);
-        row = (int) (p_board->rows * (float) rand() / RAND_MAX + 1);
+        col = rand() % p_board->cols + 1;
+        row = rand() % p_board->rows + 1;
 
         if( !p_board->box[col][row].IsMine ) {
             i++;


### PR DESCRIPTION
Please, apply this patch to fix placing mines outside the game field. Or if it is preferred way you can just check out the same patches from here: https://source.winehq.org/git/wine.git/history/HEAD:/programs/winemine/main.c

Also you can read my investigation here: https://github.com/BrokeRU/WineMine-Investigation
